### PR TITLE
Potential fix for code scanning alert no. 2: Call to System.IO.Path.Combine

### DIFF
--- a/Jellyfin.Plugin.PDFCover/Plugin.cs
+++ b/Jellyfin.Plugin.PDFCover/Plugin.cs
@@ -55,7 +55,7 @@ public class Plugin : BasePlugin<PluginConfiguration>
                 {
                     string rid = $"{osPrefix}-{arch}";
                     string pluginFolder = Path.GetDirectoryName(typeof(Plugin).Assembly.Location)!;
-                    string nativePath = Path.Combine(pluginFolder, "runtimes", rid, "native", libName);
+                    string nativePath = Path.Join(pluginFolder, "runtimes", rid, "native", libName);
 
                     if (File.Exists(nativePath))
                     {


### PR DESCRIPTION
Potential fix for [https://github.com/unfedorg/jellyfin-plugin-pdfcover/security/code-scanning/2](https://github.com/unfedorg/jellyfin-plugin-pdfcover/security/code-scanning/2)

To fix the issue, replace `Path.Combine` with `Path.Join` where you are strictly concatenating path segments and then later validating the resulting path (via `File.Exists` in this case). `Path.Join` does not discard earlier segments when later ones are absolute; instead, it simply joins the segments, which avoids the silent‑truncation behavior of `Path.Combine`.

Concretely, in `Jellyfin.Plugin.PDFCover/Plugin.cs`, inside the `Plugin` constructor’s `SetDllImportResolver` callback, change the declaration of `nativePath` on line 58 from using `Path.Combine(pluginFolder, "runtimes", rid, "native", libName)` to `Path.Join(pluginFolder, "runtimes", rid, "native", libName)`. No additional imports or helpers are needed because `System.IO` is already imported and `Path.Join` is available in modern .NET versions. This change preserves the resolved path layout and keeps the existing `File.Exists(nativePath)` check and subsequent `NativeLibrary.Load(nativePath)` call unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
